### PR TITLE
revert default baud

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 #define LED3        PA2 // Blue
 
 #ifndef BAUD_RATE
-#define BAUD_RATE   57600
+#define BAUD_RATE   4800 // 57600
 #endif // BAUD_RATE
 
 


### PR DESCRIPTION
Revert baud back to 4800 (smart audio) until https://github.com/OpenVTx/OpenVTx/pull/40 is merged.