### PR TITLE
update default BAUD_RATE to use 2 stopbits

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 #define LED3        PA2 // Blue
 
 #ifndef BAUD_RATE
-#define BAUD_RATE   4801 // 57600
+#define BAUD_RATE   4801 // Default for SmartAudio
 #endif // BAUD_RATE
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 #define LED3        PA2 // Blue
 
 #ifndef BAUD_RATE
-#define BAUD_RATE   4800 // 57600
+#define BAUD_RATE   4801 // 57600
 #endif // BAUD_RATE
 
 


### PR DESCRIPTION
This is default for SA.