### PR TITLE
button recovery

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,12 +5,13 @@
 #include "helpers.h"
 
 
-#define UART_RX     PA9
-#define UART_TX     PA9
-#define LED1        PA4 // Red
-#define LED2        PA3 // Green
-#define LED3        PA2 // Blue
-#define BUTTON      PA6
+#define UART_RX         PA9
+#define UART_TX         PA9
+#define LED1            PA4 // Red
+#define LED2            PA3 // Green
+#define LED3            PA2 // Blue
+#define BUTTON          PA6
+#define DEBOUNCE_TIME   50
 
 #ifndef BAUD_RATE
 #define BAUD_RATE   4801 // Default for SmartAudio
@@ -126,8 +127,19 @@ void setup(void)
     int baudrate = check_bootloader_data();
 
 #ifdef BUTTON
+    bool didButtonBounce = FALSE;
     if (gpio_in_read(buttonPin) == BUTTON_PRESSED)
-        baudrate = BAUD_RATE;
+    {
+        uint32_t now = millis();
+        while (millis() < now + DEBOUNCE_TIME)
+        {
+            if (gpio_in_read(buttonPin) == BUTTON_RELEASED)
+                didButtonBounce = TRUE;
+        }
+
+        if (!didButtonBounce)
+            baudrate = BAUD_RATE;
+    }
 #endif
 
     /* Check if the bootloader update was requested */

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #define LED1        PA4 // Red
 #define LED2        PA3 // Green
 #define LED3        PA2 // Blue
+#define BUTTON      PA6
 
 #ifndef BAUD_RATE
 #define BAUD_RATE   4801 // Default for SmartAudio
@@ -18,6 +19,11 @@
 
 static uint32_t boot_start_time;
 
+enum
+{
+  BUTTON_PRESSED,
+  BUTTON_RELEASED
+};
 
 #ifdef LED1
 static gpio_out_t led1_pin;
@@ -27,6 +33,9 @@ static gpio_out_t led2_pin;
 #endif
 #ifdef LED3
 static gpio_out_t led3_pin;
+#endif
+#ifdef BUTTON
+static gpio_in_t buttonPin;
 #endif
 
 void status_leds_init(void)
@@ -39,6 +48,13 @@ void status_leds_init(void)
 #endif
 #ifdef LED3
     led3_pin = gpio_out_setup(LED3, 0);
+#endif
+}
+
+void button_init(void)
+{
+#ifdef BUTTON
+    buttonPin = gpio_in_setup(BUTTON, 0);
 #endif
 }
 
@@ -102,11 +118,17 @@ void setup(void)
     fwdgt_window_value_config(0x0FFF);
     fwdgt_enable(); // Enable watchdog
     status_leds_init();
+    button_init();
 
     /* Reset WD */
     fwdgt_counter_reload();
 
     int baudrate = check_bootloader_data();
+
+#ifdef BUTTON
+    if (gpio_in_read(buttonPin) == BUTTON_PRESSED)
+        baudrate = BAUD_RATE;
+#endif
 
     /* Check if the bootloader update was requested */
     if (0 <= baudrate) {

--- a/src/main.c
+++ b/src/main.c
@@ -127,17 +127,10 @@ void setup(void)
     int baudrate = check_bootloader_data();
 
 #ifdef BUTTON
-    bool didButtonBounce = FALSE;
     if (gpio_in_read(buttonPin) == BUTTON_PRESSED)
     {
-        uint32_t now = millis();
-        while (millis() < now + DEBOUNCE_TIME)
-        {
-            if (gpio_in_read(buttonPin) == BUTTON_RELEASED)
-                didButtonBounce = TRUE;
-        }
-
-        if (!didButtonBounce)
+        delay(DEBOUNCE_TIME);
+        if (gpio_in_read(buttonPin) == BUTTON_PRESSED)
             baudrate = BAUD_RATE;
     }
 #endif


### PR DESCRIPTION
If the button is held during power up the VTx will start in bootloader mode, using the default SA serial settings.  This is useful if a users has a bad flash, which means the VTx is unable to be reset into BL mode for flashing via the Configurator.

Requires https://github.com/OpenVTx/Openvtx-configurator/pull/6 to work.

To recover from a bad flash;
- Setup the FC with SmartAudio.  This is the default recovery protocol used by the bootloader firmware.
- Attempt to flash via the Configurator.  This will fail due to the bricked VTx, but place the FC into passthrough mode.
- Without disconnecting USB and power cycling the FC, power cycle only the VTx while holding the button down e.g. power the craft via battery.  Most FCs will not power the VTx with only USB.
- The VTx red LED should blink at about twice per second to indicate BL mode.
- Flashing again via the Configurator should now work.
