### PR TITLE
Lock stm32duino version to 1.0.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ platform_packages =
     maxgerhardt/framework-spl@2.10300.0
     platformio/tool-dfuutil@1.11.0
     platformio/tool-openocd@2.1100.211028
-	platformio/tool-stm32duino@1.0.2
+    platformio/tool-stm32duino@1.0.1
     platformio/toolchain-gccarmnoneeabi@1.70201.0
 framework = spl
 board = gd32f130g6


### PR DESCRIPTION
Changing to keep it the same as the main repo.

https://github.com/OpenVTx/OpenVTx/pull/69